### PR TITLE
Fixed 'No Security Panel Found' error

### DIFF
--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -95,7 +95,7 @@ class TotalConnectClient:
         """Find the device id of the security panel."""
         deviceId = False
         for device in location['DeviceList']['DeviceInfoBasic']:
-            if device['DeviceName'] == 'Security Panel':
+            if device['DeviceName'] == 'Security Panel' or device['DeviceName'] == 'Security System':
                 deviceId = device['DeviceID']
 
         if deviceId is False:


### PR DESCRIPTION
The Total Connect API lists my ```DeviceName``` as ```Security System``` instead of ```Security Panel```.  I'm not sure if they have updated this for all devices or it is just the newer ones (Honeywell Lyric Controller).  I added in the alternate ```DeviceName``` and am no longer getting the error mentioned in issue #4 @wardcraigj 