### PR TITLE
adding ARMED_CUSTOM_BYPASS alarm code

### DIFF
--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -14,6 +14,7 @@ class TotalConnectClient:
     ARMED_AWAY_BYPASS = 10202
     ARMED_AWAY_INSTANT = 10205
     ARMED_AWAY_INSTANT_BYPASS = 10206
+    ARMED_CUSTOM_BYPASS = 10223
     ARMED_STAY = 10203
     ARMED_STAY_BYPASS = 10204
     ARMED_STAY_INSTANT = 10209
@@ -152,6 +153,8 @@ class TotalConnectClient:
         elif alarm_code == 10210:
             return True
         elif alarm_code == 10218:
+            return True
+        elif alarm_code == 10223:
             return True
         else:
             return False


### PR DESCRIPTION
My lyric controller has the ability to arm only certain zones.  This is called "Armed Custom Bypass" and as a different alarm code.  This PR adds that alarm code so the status in home assistant isn't ```UNKNOWN```

![image](https://user-images.githubusercontent.com/1053584/32798092-b030b462-c941-11e7-81ed-0066752e7cee.png)
