### PR TITLE
Adding recognition of panel named Lynx Touch-WiFi

### DIFF
--- a/total_connect_client/TotalConnectClient.py
+++ b/total_connect_client/TotalConnectClient.py
@@ -142,7 +142,7 @@ class TotalConnectClient:
         """Find the device id of the security panel."""
         deviceId = False
         for device in location['DeviceList']['DeviceInfoBasic']:
-            if device['DeviceName'] == 'Security Panel' or device['DeviceName'] == 'Security System' or device['DeviceName'] == 'L5100-WiFi':
+            if device['DeviceName'] == 'Security Panel' or device['DeviceName'] == 'Security System' or device['DeviceName'] == 'L5100-WiFi' or device['DeviceName'] == 'Lynx Touch-WiFi':
                 deviceId = device['DeviceID']
 
         if deviceId is False:


### PR DESCRIPTION
I'm having the same problem as issue #14 (Panel named 'Lynx Touch-WiFi').  Added in additional case to account for this panel name.